### PR TITLE
Blogpost:  Running ownCloud with Caddy

### DIFF
--- a/public/blog/caddy_and_owncloud.md
+++ b/public/blog/caddy_and_owncloud.md
@@ -1,8 +1,8 @@
-    ---
-    title: Running ownCloud with Caddy
-    author: Mathias Beke
-    date: 2015-09-15 12:00:00
-    ---
+---
+title: Running ownCloud with Caddy
+author: Mathias Beke
+date: 2015-09-15 12:00:00
+---
 
 Running ownCloud with Caddy
 ===========================
@@ -55,7 +55,8 @@ Now you have a user `owncloud` with password `somepassword` which has access to 
 Installing PHP-FPM
 ------------------
 
-Note: install PHP >= 5.6, ownCloud doesn't play well with PHP-FPM 5.5.9.
+* Note: Install PHP >= 5.6, ownCloud doesn't play well with PHP-FPM 5.5.9.  
+* Note: At the time of writing PHP 7 isn't there yet, but it soon will be. Apparently [ownCloud does support](https://github.com/owncloud/core/issues/16641) PHP 7.
 
 You also need to install PHP-FPM before you can actually install ownCloud.
 
@@ -85,6 +86,8 @@ If you need previews for videos and documents you also need to install the follo
 To secure your PHP-FPM installation you better disable path fixing.  
 Add the line `fix.pathinfo=0` to the `/etc/php5/fpm/php.ini` file.
 
+*Don't forget to restart PHP-FPM: `sudo service php5-fpm restart`.*
+
 Caddyfile
 ---------
 
@@ -98,11 +101,18 @@ The following Caddyfile should work with ownCloud.
         root owncloud
         tls server.crt server.key
         log access.log
+        errors error.log
     
         # PHP-FPM with Unix socket
-        fastcgi / /var/run/php5-fpm.sock php
+        fastcgi / /var/run/php5-fpm.sock php {
+            env PATH /bin
+        }
         
-        # TODO: add routes
+        # Rewrites for ownCloud
+        rewrite {
+            regexp /index.php/.*
+            to /index.php?{query}
+        }
     }
 
 Feel free to check my personal blog if you need help [generating a self-signed certificate](https://denbeke.be/blog/servers/creating-a-self-signed-ssl-certificate-on-linux/).
@@ -111,8 +121,8 @@ If you want to test your Caddyfile / PHP installation, you can create a `phpinfo
 
     <?php phpinfo(); ?>
 
-Navigate then to `https://my-owncloud-site.com/phpinfo.php` with your browser and check if the default PHP info page is displayed. (of course after Caddy is running with your Caddyfile)   
-*Don't forget to delete this file after everything is working!*
+Then navigate to `https://my-owncloud-site.com/phpinfo.php` with your browser and check if the default PHP info page is displayed. (of course after Caddy is running with your Caddyfile)   
+*Don't forget to delete this file after everything is working! Other people don't need to know your exact PHP installation with limits and extensions.*
 
 
 Installing & Configuring ownCloud
@@ -135,6 +145,4 @@ If everything works fine, you will see the ownCloud configuration screen.
 However, you need to create a `data` folder for ownCloud and give ownCloud (i.e. `www-data` user) write/read access to it.
 
     $ mkdir owncloud/data
-    $ chgrp www-data owncloud/data/
-    $ chmod 770 owncloud/data/
-
+    $ sudo chown -R www-data owncloud

--- a/public/blog/caddy_and_owncloud.md
+++ b/public/blog/caddy_and_owncloud.md
@@ -1,11 +1,13 @@
 ---
 title: Running ownCloud with Caddy
 author: Mathias Beke
-date: 2015-09-15 12:00:00
+date: 2015-03-16 12:00:00
 ---
 
 Running ownCloud with Caddy
 ===========================
+
+In this post, I'll walk you through how to set up ownCloud with Caddy for a secure, personal cloud service.
 
 ownCloud
 --------
@@ -91,7 +93,7 @@ If you need previews for videos and documents you also need to install the follo
 Caddyfile
 ---------
 
-I made the following Caddyfile together with *mholt* and *dprandzioch*. The config contains everything you need for hosting OwnCloud server and also supports the desktop and mobile clients.
+I made the following Caddyfile together with *mholt* and *dprandzioch*. The config contains everything you need for hosting ownCloud server and also supports the desktop and mobile clients.
 
     my-owncloud-site.com {
     
@@ -104,7 +106,7 @@ I made the following Caddyfile together with *mholt* and *dprandzioch*. The conf
         }
     
         rewrite {
-            regexp /index.php/.*
+            r ^/index.php/.*$
             to /index.php?{query}
         }
     
@@ -123,10 +125,7 @@ I made the following Caddyfile together with *mholt* and *dprandzioch*. The conf
             to /remote.php/{1}/{2}
         }
     
-        # this is still insanely insecure as all user files are located
-        # within the docroot and intended .htaccess restrictions are not interpreted
-        # Deny access copied from the nginx config at
-        # https://doc.owncloud.org/server/8.0/admin_manual/installation/nginx_configuration.html
+        # .htacces / data / config / ... shouldn't be accessible from outside
         rewrite {
             r  ^/(?:\.htaccess|data|config|db_structure\.xml|README)
             status 403
@@ -134,7 +133,7 @@ I made the following Caddyfile together with *mholt* and *dprandzioch*. The conf
         
     }
 
-Thanks to Caddy's [Let's Encrypt](https://letsencrypt.org) integration, our OwnCloud installation is automatically secured and served over HTTPS. Access and error logs are written to the OwnCloud folder, and the data folder (together with other special files) is protected against requests from the outside.
+Thanks to Caddy's [Let's Encrypt](https://letsencrypt.org) integration, our ownCloud installation is automatically secured and served over HTTPS. Access and error logs are written to the ownCloud folder, and the data folder (together with other special files) is protected against requests from the outside.
 
 If you want to test your Caddyfile / PHP installation, you can create a `phpinfo.php` file in the `owncloud` directory, and put the following line into it:
 
@@ -157,8 +156,7 @@ Unzip the files into the `owncloud` directory:
 
     $ unzip owncloud-9.0.0.zip
 
-Go to `https://my-owncloud-site.com` with your web browser (of course after Caddy is running with your Caddyfile).
-
+Go to `https://my-owncloud-site.com` with your web browser.
 If everything works fine, you will see the ownCloud configuration screen.
 
 However, you need to create a `data` folder for ownCloud and give ownCloud (i.e. `www-data` user) write/read access to it.
@@ -170,7 +168,7 @@ However, you need to create a `data` folder for ownCloud and give ownCloud (i.e.
 Concluding
 ----------
 
-ownCloud works very well together with Caddy, which shows that Caddy becomes a more and more mature web server!
+Caddy's rapid development makes it a choice candidate for serving your OwnCloud installation securely and easily.
 
 This blogpost is cross-posted on my personal blog, where you can leave comments if you have any questions: [Serving ownCloud with Caddy](https://denbeke.be/blog/webdevelopment/serving-owncloud-with-caddy/)
 

--- a/public/blog/caddy_and_owncloud.md
+++ b/public/blog/caddy_and_owncloud.md
@@ -165,3 +165,12 @@ However, you need to create a `data` folder for ownCloud and give ownCloud (i.e.
 
     $ mkdir owncloud/data
     $ sudo chown -R www-data owncloud
+
+
+Concluding
+----------
+
+ownCloud works very well together with Caddy, which shows that Caddy becomes a more and more mature web server!
+
+This blogpost is cross-posted on my personal blog, where you can leave comments if you have any questions: [Serving ownCloud with Caddy](https://denbeke.be/blog/webdevelopment/serving-owncloud-with-caddy/)
+

--- a/public/blog/caddy_and_owncloud.md
+++ b/public/blog/caddy_and_owncloud.md
@@ -1,7 +1,7 @@
 ---
 title: Running ownCloud with Caddy
 author: Mathias Beke
-date: 2015-03-16 12:00:00
+date: 2016-03-16 12:00:00
 ---
 
 Running ownCloud with Caddy

--- a/public/blog/caddy_and_owncloud.md
+++ b/public/blog/caddy_and_owncloud.md
@@ -113,6 +113,12 @@ The following Caddyfile should work with ownCloud.
             regexp /index.php/.*
             to /index.php?{query}
         }
+        
+        # Rewrites for WebDav (i.e. desktop clients)
+        rewrite {
+            regexp /remote.php/.*
+            to /remote.php?{query}
+        }
     }
 
 Feel free to check my personal blog if you need help [generating a self-signed certificate](https://denbeke.be/blog/servers/creating-a-self-signed-ssl-certificate-on-linux/).

--- a/public/blog/caddy_and_owncloud.md
+++ b/public/blog/caddy_and_owncloud.md
@@ -1,0 +1,140 @@
+    ---
+    title: Running ownCloud with Caddy
+    author: Mathias Beke
+    date: 2015-09-15 12:00:00
+    ---
+
+Running ownCloud with Caddy
+===========================
+
+ownCloud
+--------
+
+A quick introduction to [ownCloud](https://owncloud.org) for those who never heard about it (as found on Wikipedia).
+
+> OwnCloud (stylized ownCloud) is a suite of client-server software for creating file hosting services and using them.
+> OwnCloud is functionally very similar to the widely used Dropbox, with the primary functional difference being that OwnCloud is free and open-source, and thereby allowing anyone to install and operate it without charge on a private server, with no limits on storage space (except for disk capacity or account quota) or the number of connected clients.
+
+
+Installing MariaDB
+------------------
+
+OwnCloud requires MySQL (or in this case) MariaDB.  
+The following command will install MariaDB server and client, and will ask you for a root password.
+
+    $ sudo apt-get install mariadb-server
+
+Once you have MariaDB installed you need to secure your installation. This will guide you through some steps.
+
+    $ sudo /usr/bin/mysql_secure_installation
+
+
+Creating the ownCloud user and database
+---------------------------------------
+
+Now you need to login to the MySQL command line with the root credentials.  
+Use the following command, and type your root password.
+
+    $ mysql -u root -p
+
+Now we create a new database for ownCloud:
+
+    MariaDB [(none)]> create database owncloud;
+
+and a new user:
+
+    MariaDB [(none)]> grant usage on *.* to owncloud@localhost identified by 'somepassword';
+
+and give that user access to the newly created database:
+
+    MariaDB [(none)]> grant all privileges on owncloud.* to owncloud@localhost;
+
+Now you have a user `owncloud` with password `somepassword` which has access to the database called `owncloud`.
+
+
+Installing PHP-FPM
+------------------
+
+Note: install PHP >= 5.6, ownCloud doesn't play well with PHP-FPM 5.5.9.
+
+You also need to install PHP-FPM before you can actually install ownCloud.
+
+    $ sudo apt-get install php5-fpm
+
+Simply installing PHP isn't enough, in order to have ownCloud working properly, you also need some extra PHP extensions.
+A list of all ownCloud requirements can be found [here](https://doc.owncloud.org/server/7.0/admin_manual/installation/source_installation.html).
+The extensions below are recommended for ownCloud and not included in the default PHP installation:
+
+- PHP mysql driver
+- PHP gd
+- PHP curl
+- PHP intl
+- PHP mcrypt
+- PHP imagick
+
+You can install them all at once:
+
+    $ sudo apt-get install php5-mysql php5-gd php5-curl php5-intl php5-mcrypt php5-imagick
+
+If you need previews for videos and documents you also need to install the following (non-PHP) packages:
+
+- ffmpeg or avconv
+- LibreOffice
+
+
+To secure your PHP-FPM installation you better disable path fixing.  
+Add the line `fix.pathinfo=0` to the `/etc/php5/fpm/php.ini` file.
+
+Caddyfile
+---------
+
+The following Caddyfile should work with ownCloud.
+
+    http://my-owncloud-site.com {
+        redir https://my-owncloud-site.com
+    }
+    
+    https://my-owncloud-site.com {
+        root owncloud
+        tls server.crt server.key
+        log access.log
+    
+        # PHP-FPM with Unix socket
+        fastcgi / /var/run/php5-fpm.sock php
+        
+        # TODO: add routes
+    }
+
+Feel free to check my personal blog if you need help [generating a self-signed certificate](https://denbeke.be/blog/servers/creating-a-self-signed-ssl-certificate-on-linux/).
+
+If you want to test your Caddyfile / PHP installation, you can create a `phpinfo.php` file in the `owncloud` directory, and put the following line into it:
+
+    <?php phpinfo(); ?>
+
+Navigate then to `https://my-owncloud-site.com/phpinfo.php` with your browser and check if the default PHP info page is displayed. (of course after Caddy is running with your Caddyfile)   
+*Don't forget to delete this file after everything is working!*
+
+
+Installing & Configuring ownCloud
+---------------------------------
+
+Now it's finally time to install ownCloud.
+
+Download the latest ownCloud version (at the time of writing `8.1.1` was the latest version, check this for yourself if you are following my tutorial):
+
+    $ wget https://download.owncloud.org/community/owncloud-8.1.1.zip
+
+Unzip the files into the `owncloud` directory:
+
+    $ unzip owncloud-8.1.1.zip
+
+Go to `https://my-owncloud-site.com` with your webbrowser (of course after Caddy is running with your Caddyfile).
+
+If everything works fine, you will see the ownCloud configuration screen.
+
+However, you need to create a `data` folder for ownCloud and give ownCloud (i.e. `www-data` user) write/read access to it.
+
+    $ mkdir owncloud/data
+    $ chgrp www-data owncloud/data/
+    $ chmod 770 owncloud/data/
+


### PR DESCRIPTION
I've worked on a blogpost concerning ownCloud. **Not yet ready to be merged**, but it can surely already be discussed. I expected that native English writers have enough stuff to correct in my post.

Other problems:

* How to fix WebDav for ownCloud (for the oC desktop clients)? Is there some Caddy directive I need to add to the Caddy file? I get this error in the client: `Error downloading https://some-site.com/remote.php/webdav/ - server replied: Method Not Allowed`. And this in the error.log: `25/Oct/2015:10:14:22 +0100 [ERROR 502 /remote.php/webdav/] malformed MIME header line: Access to the script '/home/mathias/owncloud/webdav' has been denied (see security.limit_extensions)`. Or should I look into some rewrite rule?
* If I start caddy and I go the ownCloud installation everything works fine, but after a few clicks new page loads hang. No high load or CPU on any process on my server. If I then restart caddy and go to the same page, everything works fine. Any ideas about this?

Edit: concerning the first issue, I guess it's some rewrite rule stuff, will look into it.