### PR TITLE
Adding docs for real-ip module. Trying markdown.

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,6 +12,10 @@ markdown /blog {
 	template ../blog_post_template.html
 	template index ../blog_index_template.html
 }
+markdown /docs {
+	dev
+	template includes/docs-md.html
+}
 
 # build server
 proxy /download/build localhost:5050

--- a/public/docs/realip.md
+++ b/public/docs/realip.md
@@ -1,0 +1,59 @@
+{
+	"title":"RealIP",
+	"addonRepo": "github.com/captncraig/caddy-realip"
+}
+
+The real IP module is useful in situations where you are running caddy behind a proxy server.
+In these situations the actual client ip will be stored in an HTTP header, usually `X-Forwarded-For`. The problem this creates
+is that other directives that rely on the client ip address, like [ipfilter](./ipfilter) or [git](./git), will not always work properly in these scenarios.
+
+This middleware will seamlessly and securely read the real ip adress from the appropriate header and store it in the request so that
+any downstream directives will see the real client IP address in `request.RemoteAddr`.
+
+### Syntax
+
+<code class="block"><span class="hl-directive">realip</span> {
+    <span class="hl-subdirective">header</span> <i>name</i>
+	<span class="hl-subdirective">from</span> <i>cidr</i>
+}
+</code>
+
+- **name** is the name of the header containing the actual IP address. Default is `X-Forwarded-For`.
+- **cidr** is the address range of expected proxy servers. As a security measure, IP headers are only accepted from known proxy servers. Must be a valid cidr block notation. This may be specified multiple times.
+
+### CIDR blocks
+CIDR is a standard notation for specifying IP ranges. To allow a single IP, use `/32` after the ip to specify no mask: `123.222.31.4/32`. To allow ALL Ips (and accept an `X-Forwarded-For` header from anybody), use `0.0.0.0/0`. Most cloud services should have their ip ranges published in this format somewhere.
+
+### Examples
+
+Simple usage to read `X-Forwarded-For` from a single IP only:
+
+<code class="block"><span class="hl-directive">realip {
+	<span class="hl-subdirective">from 1.2.3.4/32
+}
+</code>
+
+For servers running behind Cloudflare (blocks obtained from their [docs](https://www.cloudflare.com/ips/)):
+<code class="block"><span class="hl-directive">realip</span> {
+    <span class="hl-subdirective">from</span> 103.21.244.0/22
+    <span class="hl-subdirective">from</span> 103.22.200.0/22
+    <span class="hl-subdirective">from</span> 103.31.4.0/22
+    <span class="hl-subdirective">from</span> 104.16.0.0/12
+    <span class="hl-subdirective">from</span> 108.162.192.0/18
+    <span class="hl-subdirective">from</span> 141.101.64.0/18
+    <span class="hl-subdirective">from</span> 162.158.0.0/15
+    <span class="hl-subdirective">from</span> 172.64.0.0/13
+    <span class="hl-subdirective">from</span> 173.245.48.0/20
+    <span class="hl-subdirective">from</span> 188.114.96.0/20
+    <span class="hl-subdirective">from</span> 190.93.240.0/20
+    <span class="hl-subdirective">from</span> 197.234.240.0/22
+    <span class="hl-subdirective">from</span> 198.41.128.0/17
+    <span class="hl-subdirective">from</span> 199.27.128.0/21
+    <span class="hl-subdirective">from</span> 2400:cb00::/32
+    <span class="hl-subdirective">from</span> 2405:8100::/32
+    <span class="hl-subdirective">from</span> 2405:b500::/32
+    <span class="hl-subdirective">from</span> 2606:4700::/32
+    <span class="hl-subdirective">from</span> 2803:f800::/32
+    <span class="hl-subdirective">header</span> X-Forwarded-For
+}
+</code>

--- a/public/docs/realip.md
+++ b/public/docs/realip.md
@@ -15,45 +15,32 @@ any downstream directives will see the real client IP address in `request.Remote
 <code class="block"><span class="hl-directive">realip</span> {
     <span class="hl-subdirective">header</span> <i>name</i>
 	<span class="hl-subdirective">from</span> <i>cidr</i>
+	<span class="hl-subdirective">strict</span>
 }
 </code>
 
 - **name** is the name of the header containing the actual IP address. Default is `X-Forwarded-For`.
 - **cidr** is the address range of expected proxy servers. As a security measure, IP headers are only accepted from known proxy servers. Must be a valid cidr block notation. This may be specified multiple times.
+- **strict**, if specified will reject requests from unkown proxy ips with a 403. If not specified, it will simply leave the original ip in place.
 
 ### CIDR blocks
 CIDR is a standard notation for specifying IP ranges. To allow a single IP, use `/32` after the ip to specify no mask: `123.222.31.4/32`. To allow ALL Ips (and accept an `X-Forwarded-For` header from anybody), use `0.0.0.0/0`. Most cloud services should have their ip ranges published in this format somewhere.
 
 ### Examples
 
-Simple usage to read `X-Forwarded-For` from a single IP only:
+Simple usage to read `X-Forwarded-For` from a few known IPs only:
 
 <code class="block"><span class="hl-directive">realip {
-	<span class="hl-subdirective">from 1.2.3.4/32
+	<span class="hl-subdirective">from 1.2.3.4/32</span>
+	<span class="hl-subdirective">from 2.3.4.5/32</span>
 }
 </code>
 
-For servers running behind Cloudflare (blocks obtained from their [docs](https://www.cloudflare.com/ips/)):
-<code class="block"><span class="hl-directive">realip</span> {
-    <span class="hl-subdirective">from</span> 103.21.244.0/22
-    <span class="hl-subdirective">from</span> 103.22.200.0/22
-    <span class="hl-subdirective">from</span> 103.31.4.0/22
-    <span class="hl-subdirective">from</span> 104.16.0.0/12
-    <span class="hl-subdirective">from</span> 108.162.192.0/18
-    <span class="hl-subdirective">from</span> 141.101.64.0/18
-    <span class="hl-subdirective">from</span> 162.158.0.0/15
-    <span class="hl-subdirective">from</span> 172.64.0.0/13
-    <span class="hl-subdirective">from</span> 173.245.48.0/20
-    <span class="hl-subdirective">from</span> 188.114.96.0/20
-    <span class="hl-subdirective">from</span> 190.93.240.0/20
-    <span class="hl-subdirective">from</span> 197.234.240.0/22
-    <span class="hl-subdirective">from</span> 198.41.128.0/17
-    <span class="hl-subdirective">from</span> 199.27.128.0/21
-    <span class="hl-subdirective">from</span> 2400:cb00::/32
-    <span class="hl-subdirective">from</span> 2405:8100::/32
-    <span class="hl-subdirective">from</span> 2405:b500::/32
-    <span class="hl-subdirective">from</span> 2606:4700::/32
-    <span class="hl-subdirective">from</span> 2803:f800::/32
-    <span class="hl-subdirective">header</span> X-Forwarded-For
-}
-</code>
+
+
+### Presets
+
+There is a helper supplied if you want to use caddy behind cloudflare. Simply specify `realip cloudflare` in your caddyfile to activate it using a 
+built-in ip list.
+
+Additional presets would be welcome by pull request for other cloud providers.

--- a/public/includes/docs-md.html
+++ b/public/includes/docs-md.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>{{.Doc.title}} - Caddy Directives</title>
+		{{.Include "/includes/docs-head.html"}}
+	</head>
+	<body>
+		<main>
+			<h1>{{.Doc.title}} {{if .Doc.addonRepo}}<div class="tag addon">Addon</div>{{end}}</h1>
+			{{if .Doc.addonRepo}}
+			<div class="addon-message">
+				<div class="heading"><i class="fa fa-plus-circle"></i> Addon</div>
+				This directive is a Caddy extension. Questions should be directed to its maintainer. <a href="https://{{.Doc.addonRepo}}">{{.Doc.addonRepo}}</a>
+			</div>
+			{{end}}
+			{{.Doc.body}}
+		</main>
+
+		{{.Include "/includes/docs-nav.html"}}
+	</body>
+</html>

--- a/public/includes/docs-nav.html
+++ b/public/includes/docs-nav.html
@@ -44,6 +44,7 @@
 		<li><a href="/docs/mime">mime</a></li>
 		<li><a href="/docs/prometheus" title="Add-on">prometheus<span class="addon">A</span></a></li>
 		<li><a href="/docs/proxy">proxy</a></li>
+		<li><a href="/docs/realip">realip<span class="addon">A</span></a></li>
 		<li><a href="/docs/redir">redir</a></li>
 		<li><a href="/docs/rewrite">rewrite</a></li>
 		<li><a href="/docs/root">root</a></li>


### PR DESCRIPTION
Wanted to see how markdown works. This certainly feels more natural than hand coding all of the html. Has a common docs template that only requires a few fields in front matter.

The only thing not working super great is the formatting on the code snippets. Perhaps some kind of javascript highlighting could be adapted, but I'm not sure how much of a dealbreaker that would be.