### PR TITLE
Clarify that tls off makes port 2015 the default.

### DIFF
--- a/public/docs/tls.html
+++ b/public/docs/tls.html
@@ -26,7 +26,7 @@
 			<code class="block"><span class="hl-directive">tls</span> <span class="hl-arg">off</span></code>
 
 			<p>
-				Disables TLS for the site. Not recommended unless you have a good reason. Note that Caddy now defaults to port 2015 again.
+				Disables TLS for the site. Not recommended unless you have a good reason. With TLS off, automatic HTTPS is also disabled, so the default port (2015) will not be changed.
 			</p>
 
 			<code class="block"><span class="hl-directive">tls</span> <span class="hl-arg"><i>email</i></span></code>

--- a/public/docs/tls.html
+++ b/public/docs/tls.html
@@ -26,7 +26,7 @@
 			<code class="block"><span class="hl-directive">tls</span> <span class="hl-arg">off</span></code>
 
 			<p>
-				Disables TLS for the site. Not recommended unless you have a good reason.
+				Disables TLS for the site. Not recommended unless you have a good reason. Note that Caddy now defaults to port 2015 again.
 			</p>
 
 			<code class="block"><span class="hl-directive">tls</span> <span class="hl-arg"><i>email</i></span></code>


### PR DESCRIPTION
As discussed in https://github.com/mholt/caddy/issues/384, its a little
bit unintuitive that switching tls off makes 2015 the default port
especially when the site were served on 80 and 443 before doing so.