### PR TITLE
Fix typo

### DIFF
--- a/content/docs/automatic-https.md
+++ b/content/docs/automatic-https.md
@@ -133,7 +133,7 @@ To serve a site over HTTPS, a valid SSL certificate is required from a trusted c
 
 If necessary, Caddy creates an account on the CA's server with (or without) your email address. Caddy may have to prompt you for an email address if it is not able to find one from the Caddyfile, in the command line flags, or on disk from a previous run. Also, if the CA's legal agreements have changed, you may be prompted to agree to them if you did not already do so with the `-agree` flag.
 
-Once the formalities are taken care of, Caddy generates a private key and a Certificate Signing Request (CSR) for each site. The private keys never leave the server and are safely stowed on your file system.
+Once the formalities are taken care of, Caddy generates a private key and a Certificate Signing Request (CSR) for each site. The private keys never leave the server and are safely stored on your file system.
 
 Caddy establishes a link with the CA's server. A brief cryptographic transaction takes place to prove that Caddy really is serving the sites it says it is. Once the CA server verifies this, it sends the certificate for that site over the wire to Caddy, which tucks it neatly away in the .caddy folder.
 


### PR DESCRIPTION
This is the second typo I found. I don't remember the first one but I couldn't find this repository at the time. Even now it took me a good 5 min of searching through closed PR comments on mholt/caddy until I found a link that pointed to this repo.

If you don't mind I would open a new PR on mholt/caddy for updating the contributing section of the readme and mention this repo for people that want to contribute to and improve the caddy documentation. Let me know what you think!