### PR TITLE
Fixed second rewrite in Owncloud Caddyfile

### DIFF
--- a/content/blog/caddy_and_owncloud.md
+++ b/content/blog/caddy_and_owncloud.md
@@ -128,7 +128,7 @@ I made the following Caddyfile together with *mholt* and *dprandzioch*. The conf
         }
 
         rewrite {
-            r ^/remote.php/(webdav|caldav|carddav|dav)/(.+)(\/?)$
+            r ^/remote.php/(webdav|caldav|carddav|dav)/(.+?)(\/?)$
             to /remote.php/{1}/{2}
         }
 


### PR DESCRIPTION
I noticed that `^/remote.php/(webdav|caldav|carddav|dav)/(.+?)(\/?)$` was greedy, meaning that a last `/` would still be included in the `{2}` group, resulting in php-fpm still having issues with the incoming url's. Making that second group not greedy seems to fix this.

I also placed a comment on the author's blog; https://denbeke.be/blog/webdevelopment/serving-owncloud-with-caddy/#comment-2886944259