### PR TITLE
awslambda: add single and strip_path_prefix docs

### DIFF
--- a/content/docs/awslambda.md
+++ b/content/docs/awslambda.md
@@ -26,6 +26,8 @@ the Lambda functions to conform to the response JSON envelope format.
     <span class="hl-subdirective">exclude</span>       <i>excluded function names...</i>
     <span class="hl-subdirective">name_prepend</span>  <i>string to prepend to function name</i>
     <span class="hl-subdirective">name_append</span>   <i>string to append to function name</i>
+    <span class="hl-subdirective">single</span>   <i>name of a single lambda function to invoke</i>
+    <span class="hl-subdirective">strip_path_prefix</span>   <i>If true, path and function name are stripped from the path</i>
 }</code>
 
 *   **aws_access** is the AWS Access Key to use when invoking Lambda functions. If omitted, the AWS_ACCESS_KEY_ID env var is used.
@@ -36,16 +38,21 @@ the Lambda functions to conform to the response JSON envelope format.
 *   **exclude** is an optional space separated list of function names to exclude. Prefix and suffix globs are supported.
 *   **name_prepend** is an optional string to prepend to the function name parsed from the URL before invoking the Lambda.
 *   **name_append** is an optional string to append to the function name parsed from the URL before invoking the Lambda.
+*   **single** is an optional function name. If set, function name is not parsed from the URI path.
+*   **strip_path_prefix** If 'true', path and function name is stripped from the path sent as request metadata to the Lambda function. (default=false)
 
 Function names are parsed from the portion of request path following the path-prefix in the
-directive. For example, given a directive `awslambda /lambda/`, a request to `/lambda/hello-world`
-would invoke the AWS Lambda function named `hello-world`.
+directive based on this convention: `[path-prefix]/[function-name]/[extra-path-info]` unless `single` attribute is set.
+
+For example, given a directive `awslambda /lambda/`, requests to `/lambda/hello-world` and `/lambda/hello-world/abc`
+would each invoke the AWS Lambda function named `hello-world`.
 
 The `include` and `exclude` globs are simple wildcards, not regular expressions.
 For example, `include foo*` would match `food` and `footer` but not `buffoon`, while
 `include *foo*` would match all three.
 
-`include` and `exclude` rules are run before `name_prepend` and `name_append` are applied.
+`include and `exclude` rules are run before `name_prepend` and `name_append` are applied and
+are run against the parsed function name, not the entire URL path.
 
 If you adopt a simple naming convention for your Lambda functions, these rules can be used to
 group access to a set of Lambdas under a single URL path prefix.

--- a/content/docs/awslambda.md
+++ b/content/docs/awslambda.md
@@ -18,16 +18,16 @@ the Lambda functions to conform to the response JSON envelope format.
 ### Syntax
 
 <code class="block"><span class="hl-directive">awslambda</span> <span class="hl-arg"><i>path-prefix</i></span> {
-    <span class="hl-subdirective">aws_access</span>    <i>aws access key value</i>
-    <span class="hl-subdirective">aws_secret</span>    <i>aws secret key value</i>
-    <span class="hl-subdirective">aws_region</span>    <i>aws region name</i>
-    <span class="hl-subdirective">qualifier</span>     <i>qualifier value</i>
-    <span class="hl-subdirective">include</span>       <i>included function names...</i>
-    <span class="hl-subdirective">exclude</span>       <i>excluded function names...</i>
-    <span class="hl-subdirective">name_prepend</span>  <i>string to prepend to function name</i>
-    <span class="hl-subdirective">name_append</span>   <i>string to append to function name</i>
-    <span class="hl-subdirective">single</span>   <i>name of a single lambda function to invoke</i>
-    <span class="hl-subdirective">strip_path_prefix</span>   <i>If true, path and function name are stripped from the path</i>
+    <span class="hl-subdirective">aws_access</span>         <i>aws access key value</i>
+    <span class="hl-subdirective">aws_secret</span>         <i>aws secret key value</i>
+    <span class="hl-subdirective">aws_region</span>         <i>aws region name</i>
+    <span class="hl-subdirective">qualifier</span>          <i>qualifier value</i>
+    <span class="hl-subdirective">include</span>            <i>included function names...</i>
+    <span class="hl-subdirective">exclude</span>            <i>excluded function names...</i>
+    <span class="hl-subdirective">name_prepend</span>       <i>string to prepend to function name</i>
+    <span class="hl-subdirective">name_append</span>        <i>string to append to function name</i>
+    <span class="hl-subdirective">single</span>             <i>name of a single lambda function to invoke</i>
+    <span class="hl-subdirective">strip_path_prefix</span>  <i>If true, path and function name are stripped from the path</i>
 }</code>
 
 *   **aws_access** is the AWS Access Key to use when invoking Lambda functions. If omitted, the AWS_ACCESS_KEY_ID env var is used.
@@ -51,7 +51,7 @@ The `include` and `exclude` globs are simple wildcards, not regular expressions.
 For example, `include foo*` would match `food` and `footer` but not `buffoon`, while
 `include *foo*` would match all three.
 
-`include and `exclude` rules are run before `name_prepend` and `name_append` are applied and
+`include` and `exclude` rules are run before `name_prepend` and `name_append` are applied and
 are run against the parsed function name, not the entire URL path.
 
 If you adopt a simple naming convention for your Lambda functions, these rules can be used to


### PR DESCRIPTION
Add docs for `single` and `strip_path_prefix` config options.
