### PR TITLE
Clarify that site address is per-vhost, not global

### DIFF
--- a/content/docs/caddyfile.md
+++ b/content/docs/caddyfile.md
@@ -17,7 +17,8 @@ If your Caddyfile is within the root of your site, don't worry. Caddy will respo
 
 ### Syntax
 
-The Caddyfile always starts with the address of the site to serve:
+The Caddyfile consists of multiple (1 or more) virtual host configurations.
+Each host configuration must start with the address of the site to serve:
 
 <code class="block"><span class="hl-vhost">localhost:2020</span></code>
 


### PR DESCRIPTION
Having just started with caddy, I thought each Caddyfile had to start
with a global site address, which caused me to run into syntax errors.
Clarify that each vhost block needs its own site address.
(Or let me know if something else is the case!)

Follow-up from https://github.com/mholt/caddy/issues/1176.
cc @krishamoud