### PR TITLE
Clarify values of predefined log formats

### DIFF
--- a/content/docs/log.md
+++ b/content/docs/log.md
@@ -31,7 +31,7 @@ The log file can be any filename. It could also be `stdout` or `stderr` to write
 
 You can specify a custom log format with any [placeholder](/docs/placeholders) values. Log supports both request and response placeholders.
 
-Currently are two predefined formats.
+Currently there are two predefined formats.
 
 * {common} (default)
 * {combined}

--- a/content/docs/log.md
+++ b/content/docs/log.md
@@ -33,8 +33,8 @@ You can specify a custom log format with any [placeholder](/docs/placeholders) v
 
 Currently there are two predefined formats.
 
-* {common} (default)
-* {combined}
+* **{common}** (default) - `{remote} - [{when}] "{method} {uri} {proto}" {status} {size}`
+* **{combined}** - {common} appended with `"{>Referer}" "{>User-Agent}"`
 
 ### Log Rotation
 


### PR DESCRIPTION
Maybe I'm particularly dense, but it didn't occur to me that {common} and {combined} are widespread formats I could look up. It was easy enough finding their values in caddy's source, yet I see no reason why they shouldn't be presented on the log page in some manner (even if not this).

Thought I'd add a 'there' to the statement introducing the formats while I was at it. Could also go "There are currently two predefined formats."
