### PR TITLE
Typo correction

### DIFF
--- a/content/docs/fastcgi.md
+++ b/content/docs/fastcgi.md
@@ -25,7 +25,7 @@ fastcgi proxies requests to a FastCGI server. Even though the most common use fo
 *   **endpoint** is the address or Unix socket of the FastCGI server.
 *   **preset** is an optional preset name (see below).
 *   **ext** specifies the extension which, if the request URL has it, would proxy the request to FastCGI.
-*   **index** specifies how to split the URL; the split value becomes the end of the first part and anything in the URL after it becomes part of the PATH_INFO CGI variable.
+*   **split** specifies how to split the URL; the split value becomes the end of the first part and anything in the URL after it becomes part of the PATH_INFO CGI variable.
 *   **index** specifies the default file to try if a file is not specified by the URL.
 *   **env** sets an environment variable named _key_ with the given _value_; the **env** property can be used multiple times and values may use [request placeholders](/docs/placeholders).
 *   **except** is a list of space-separated request paths to be excepted from fastcgi processing, even if it matches the base path.


### PR DESCRIPTION
The term `split` was documented as `index`.