### PR TITLE
Add Rackspace to DNS HTTPS Docs

### DIFF
--- a/content/docs/automatic-https.md
+++ b/content/docs/automatic-https.md
@@ -87,6 +87,7 @@ Replace "provider" with the name of your DNS provider (in the table below). You 
 | linode        | LINODE_API_KEY                                                                          |
 | namecheap     | NAMECHEAP_API_USER<br>NAMECHEAP_API_KEY                                                 |
 | ovh           | OVH_ENDPOINT<br>OVH_APPLICATION_KEY<br>OVH_APPLICATION_SECRET<br>OVH_CONSUMER_KEY       |
+| rackspace     | RACKSPACE_USER<br>RACKSPACE_API_KEY                                                     |
 | rfc2136       | RFC2136_NAMESERVER<br>RFC2136_TSIG_ALGORITHM<br>RFC2136_TSIG_KEY<br>RFC2136_TSIG_SECRET |
 | route53       | AWS_ACCESS_KEY_ID<br>AWS_SECRET_ACCESS_KEY                                              |
 | vultr         | VULTR_API_KEY                                                                           |


### PR DESCRIPTION
Since adding DNS support for Rackspace, updating the docs...

https://github.com/caddyserver/dnsproviders/pull/3